### PR TITLE
Adds padding for paragraphs in full-width columns block

### DIFF
--- a/404.php
+++ b/404.php
@@ -28,9 +28,9 @@ get_header();
 
 	</div><!-- .section-inner -->
 
-	<?php get_template_part( 'template-parts/footer-menus-widgets' ); ?>
-
 </main><!-- #site-content -->
+
+<?php get_template_part( 'template-parts/footer-menus-widgets' ); ?>
 
 <?php
 get_footer();

--- a/index.php
+++ b/index.php
@@ -100,9 +100,10 @@ get_header();
 	?>
 
 	<?php get_template_part( 'template-parts/pagination' ); ?>
-	<?php get_template_part( 'template-parts/footer-menus-widgets' ); ?>
 
 </main><!-- #site-content -->
+
+<?php get_template_part( 'template-parts/footer-menus-widgets' ); ?>
 
 <?php
 get_footer();

--- a/searchform.php
+++ b/searchform.php
@@ -21,7 +21,7 @@ $aria_label = ( isset( $args['label'] ) && ! empty( $args['label'] ) ) ? 'aria-l
 <form role="search" <?php echo $aria_label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped above. ?> method="get" class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>">
 	<label for="<?php echo esc_attr( $unique_id ); ?>">
 		<span class="screen-reader-text"><?php echo _x( 'Search for:', 'label', 'twentytwenty' ); // phpcs:ignore: WordPress.Security.EscapeOutput.OutputNotEscaped -- core trusts translations ?></span>
-		<input type="search" id="<?php echo esc_attr( $unique_id ); ?>" class="search-field" placeholder="<?php echo esc_attr_x( 'Search &hellip;', 'placeholder', 'twentytwenty' ); ?>" value="<?php get_search_query(); ?>" name="s" />
+		<input type="search" id="<?php echo esc_attr( $unique_id ); ?>" class="search-field" placeholder="<?php echo esc_attr_x( 'Search &hellip;', 'placeholder', 'twentytwenty' ); ?>" value="<?php echo get_search_query(); ?>" name="s" />
 	</label>
 	<input type="submit" class="search-submit" value="<?php echo esc_attr_x( 'Search', 'submit button', 'twentytwenty' ); ?>" />
 </form>

--- a/singular.php
+++ b/singular.php
@@ -25,10 +25,10 @@ get_header();
 		}
 	}
 
-	get_template_part( 'template-parts/footer-menus-widgets' );
-
 	?>
 
 </main><!-- #site-content -->
+
+<?php get_template_part( 'template-parts/footer-menus-widgets' ); ?>
 
 <?php get_footer(); ?>

--- a/style.css
+++ b/style.css
@@ -4440,6 +4440,33 @@ a.to-the-top > * {
 	}
 }
 
+@media ( max-width: 599px ) {
+	
+	/* Blocks -------------------------------- */
+
+	/* BLOCK: COLUMNS */
+	
+	.alignfull > .wp-block-column > p {
+		max-width: calc(100% - 4rem);
+		margin: auto;
+	}
+}
+
+@media ( min-width: 600px ) {
+	
+	/* Blocks -------------------------------- */
+
+	/* BLOCK: COLUMNS */
+	
+	.alignfull > .wp-block-column:nth-child(odd) > p {
+		padding-left: 2rem;
+	}
+
+	.alignfull > .wp-block-column:nth-child(even) > p {
+		padding-right: 2rem;
+	}
+}
+
 @media ( min-width: 660px ) {
 
 	/* Entry Content ------------------------- */
@@ -5294,6 +5321,21 @@ a.to-the-top > * {
 		display: none;
 	}
 
+}
+
+@media (min-width: 782px) {
+	
+	/* Blocks -------------------------------- */
+
+	/* BLOCK: COLUMNS */
+	
+	.alignfull > .wp-block-column:first-child > p {
+		padding-left: 2rem;
+	}
+
+	.alignfull > .wp-block-column:last-child > p {
+		padding-right: 2rem;
+	}
 }
 
 @media ( min-width: 1000px ) {

--- a/templates/template-cover.php
+++ b/templates/template-cover.php
@@ -24,10 +24,10 @@ get_header();
 		}
 	}
 
-	get_template_part( 'template-parts/footer-menus-widgets' );
-
 	?>
 
 </main><!-- #site-content -->
+
+<?php get_template_part( 'template-parts/footer-menus-widgets' ); ?>
 
 <?php get_footer(); ?>


### PR DESCRIPTION
The media queries used here reflect the media queries for the columns block from core. The changes exclusively work for paragraphs which are direct child elements of a single `wp-block-column`, where the `wp-block-columns` wrapper is set as `alignfull`.

@media ( max-width: 599px ) : paragraphs get the same width as the section-inner class.

@media ( min-width: 600px ) : there's a maximum of two columns displayed, so all columns need to get either padding-left or padding-right via :nth-child(odd) or :nth-child(even).

@media ( min-width: 782px ) : all columns are displayed in one row, so only the first and last child items need some padding.